### PR TITLE
remove ps_product_country_tax from db_structure.sql

### DIFF
--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -55,7 +55,6 @@ class TaxCore extends ObjectModel
         ],
     ];
 
-    protected static $_product_country_tax = [];
     protected static $_product_tax_via_rules = [];
 
     protected $webserviceParameters = [

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3836,7 +3836,6 @@ class AdminImportControllerCore extends AdminController
                     Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'favorite_product`');
                 }
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attachment`');
-                Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_country_tax`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_download`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_group_reduction_cache`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_sale`');

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2160,13 +2160,6 @@ CREATE TABLE `PREFIX_memcached_servers` (
   `weight` INT(11) UNSIGNED NOT NULL
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
-CREATE TABLE `PREFIX_product_country_tax` (
-  `id_product` int(11) NOT NULL,
-  `id_country` int(11) NOT NULL,
-  `id_tax` int(11) NOT NULL,
-  PRIMARY KEY (`id_product`, `id_country`)
-) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
-
 CREATE TABLE `PREFIX_tax_rule` (
   `id_tax_rule` int(11) NOT NULL AUTO_INCREMENT,
   `id_tax_rules_group` int(11) NOT NULL,

--- a/src/Adapter/Import/ImportEntityDeleter.php
+++ b/src/Adapter/Import/ImportEntityDeleter.php
@@ -216,7 +216,6 @@ final class ImportEntityDeleter implements ImportEntityDeleterInterface
             'product_carrier',
             'cart_product',
             'product_attachment',
-            'product_country_tax',
             'product_download',
             'product_group_reduction_cache',
             'product_sale',

--- a/tests/Resources/Resetter/ProductResetter.php
+++ b/tests/Resources/Resetter/ProductResetter.php
@@ -44,7 +44,6 @@ class ProductResetter
             'product_attribute_lang',
             'product_attribute_shop',
             'product_carrier',
-            'product_country_tax',
             'product_download',
             'product_group_reduction_cache',
             'product_lang',

--- a/tools/foreignkeyGenerator/changes.php
+++ b/tools/foreignkeyGenerator/changes.php
@@ -111,20 +111,6 @@ $changes = array(
             '#unsigned' => true,
         ),
     ),
-    'product_country_tax' => array(
-        'id_product' => array(
-            '#type' => 'INT(11)',
-            '#unsigned' => true,
-        ),
-        'id_country' => array(
-            '#type' => 'INT(11)',
-            '#unsigned' => true,
-        ),
-        'id_tax' => array(
-            '#type' => 'INT(11)',
-            '#unsigned' => true,
-        ),
-    ),
     'tax_rule' => array(
         'id_tax_rule' => array(
             '#type' => 'INT(11)',

--- a/tools/foreignkeyGenerator/relations.php
+++ b/tools/foreignkeyGenerator/relations.php
@@ -1150,18 +1150,6 @@ $relations = array(
     'memcached_servers' => array(
     ),
 
-    'product_country_tax' => array(
-        'id_product' => array(
-            'product' => 'id_product',
-        ),
-        'id_country' => array(
-            'country' => 'id_country',
-        ),
-        'id_tax' => array(
-            'tax' => 'id_tax',
-        ),
-    ),
-
     'tax_rule' => array(
         'id_tax_rules_group' => array(
             'tax_rules_group' => 'id_tax_rules_group',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------->

| Questions         | Answers |
|-------------------|---------|
| **Branch?**           | develop |
| **Description?**      | Removes the creation of the `ps_product_country_tax` table from `install-dev/data/db_structure.sql`.This table has been present in the database structure for many versions of PrestaShop (at least since 1.6), but it is never used in the core, nor in native modules. It does not appear in any queries, logic, or schema relationships across the codebase.Its removal helps clean up the database schema and reduces confusion for developers and database administrators. |
| **Type?**             | refacto |
| **Category?**         | CO |
| **BC breaks?**        | no |
| **Deprecations?**     | no |
| **How to test?**      | 1. Run a fresh install using `install-dev` directory.<br>2. After installation, connect to the database and confirm that the table `ps_product_country_tax` is no longer present.<br>3. Navigate through the back office and front office to confirm everything works normally. |
| **UI Tests**          | N/A (no user interface impact) |
| **Fixed issue or discussion?** | N/A (can open discussion if needed) |
| **Related PRs**       | N/A |
| **Sponsor company**   | Friends of Presta  |
